### PR TITLE
Point HarnessBench citation to the ClawBench paper

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,104 @@
+cff-version: 1.2.0
+message: "If you use HarnessBench, please cite the sister ClawBench paper below."
+title: "HarnessBench: Comparing Agentic Harnesses on Everyday Online Tasks"
+type: software
+license: Apache-2.0
+url: "https://github.com/reacher-z/HarnessBench"
+repository-code: "https://github.com/reacher-z/HarnessBench"
+date-released: "2026-04-16"
+authors:
+  - family-names: Zhang
+    given-names: Yuxuan
+  - family-names: Wang
+    given-names: Yubo
+  - family-names: Zhu
+    given-names: Yipeng
+  - family-names: Du
+    given-names: Penghui
+  - family-names: Miao
+    given-names: Junwen
+  - family-names: Lu
+    given-names: Xuan
+  - family-names: Xu
+    given-names: Wendong
+  - family-names: Hao
+    given-names: Yunzhuo
+  - family-names: Cai
+    given-names: Songcheng
+  - family-names: Wang
+    given-names: Xiaochen
+  - family-names: Zhang
+    given-names: Huaisong
+  - family-names: Wu
+    given-names: Xian
+  - family-names: Lu
+    given-names: Yi
+  - family-names: Lei
+    given-names: Minyi
+  - family-names: Zou
+    given-names: Kai
+  - family-names: Yin
+    given-names: Huifeng
+  - family-names: Nie
+    given-names: Ping
+  - family-names: Chen
+    given-names: Liang
+  - family-names: Jiang
+    given-names: Dongfu
+  - family-names: Chen
+    given-names: Wenhu
+  - family-names: Allen
+    given-names: Kelsey R.
+preferred-citation:
+  type: article
+  title: "ClawBench: Can AI Agents Complete Everyday Online Tasks?"
+  authors:
+    - family-names: Zhang
+      given-names: Yuxuan
+    - family-names: Wang
+      given-names: Yubo
+    - family-names: Zhu
+      given-names: Yipeng
+    - family-names: Du
+      given-names: Penghui
+    - family-names: Miao
+      given-names: Junwen
+    - family-names: Lu
+      given-names: Xuan
+    - family-names: Xu
+      given-names: Wendong
+    - family-names: Hao
+      given-names: Yunzhuo
+    - family-names: Cai
+      given-names: Songcheng
+    - family-names: Wang
+      given-names: Xiaochen
+    - family-names: Zhang
+      given-names: Huaisong
+    - family-names: Wu
+      given-names: Xian
+    - family-names: Lu
+      given-names: Yi
+    - family-names: Lei
+      given-names: Minyi
+    - family-names: Zou
+      given-names: Kai
+    - family-names: Yin
+      given-names: Huifeng
+    - family-names: Nie
+      given-names: Ping
+    - family-names: Chen
+      given-names: Liang
+    - family-names: Jiang
+      given-names: Dongfu
+    - family-names: Chen
+      given-names: Wenhu
+    - family-names: Allen
+      given-names: Kelsey R.
+  journal: "arXiv preprint arXiv:2604.08523"
+  year: 2026
+  url: "https://arxiv.org/abs/2604.08523"
+  identifiers:
+    - type: other
+      value: "arXiv:2604.08523"
+      description: arXiv preprint identifier

--- a/README.md
+++ b/README.md
@@ -440,17 +440,17 @@ Apache-2.0 for the repository. Each bundled harness adapter links to upstream co
 
 ## Citation
 
-<!-- Placeholder: replace with full arXiv block once preprint is submitted. -->
-
-If you use HarnessBench in your research, please cite:
+HarnessBench is the harness-comparison sister project of [ClawBench](https://github.com/reacher-z/ClawBench). If you use HarnessBench in your research, please cite the ClawBench paper:
 
 ```bibtex
-@misc{zhang2026harnessbench,
-  title        = {HarnessBench: Comparing Agentic Harnesses on Everyday Online Tasks},
-  author       = {Yuxuan Zhang and Yubo Wang and Yipeng Zhu and Penghui Du and Junwen Miao and Xuan Lu and Wendong Xu and Yunzhuo Hao and Songcheng Cai and Xiaochen Wang and Huaisong Zhang and Xian Wu and Yi Lu and Minyi Lei and Kai Zou and Huifeng Yin and Ping Nie and Liang Chen and Dongfu Jiang and Wenhu Chen and Kelsey R. Allen},
-  year         = {2026},
-  note         = {Preprint in preparation},
-  howpublished = {\url{https://github.com/reacher-z/HarnessBench}}
+@misc{zhang2026clawbench,
+  title         = {ClawBench: Can AI Agents Complete Everyday Online Tasks?},
+  author        = {Yuxuan Zhang and Yubo Wang and Yipeng Zhu and Penghui Du and Junwen Miao and Xuan Lu and Wendong Xu and Yunzhuo Hao and Songcheng Cai and Xiaochen Wang and Huaisong Zhang and Xian Wu and Yi Lu and Minyi Lei and Kai Zou and Huifeng Yin and Ping Nie and Liang Chen and Dongfu Jiang and Wenhu Chen and Kelsey R. Allen},
+  year          = {2026},
+  eprint        = {2604.08523},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.AI},
+  url           = {https://arxiv.org/abs/2604.08523}
 }
 ```
 


### PR DESCRIPTION
HarnessBench is the sister project of [ClawBench](https://github.com/reacher-z/ClawBench); per your request, the citation now points at the **ClawBench arXiv paper** (`arXiv:2604.08523`) — same BibTeX block that ClawBench's own README uses — instead of the prior placeholder `@misc{zhang2026harnessbench, note = "Preprint in preparation"}` block.

## Changes

- **README.md** — replaced the HarnessBench placeholder `@misc` block with the ClawBench `@misc` block (verbatim from `reacher-z/ClawBench` `README.md` lines 629-639). Added a one-line lead-in explaining HarnessBench shares the ClawBench citation.
- **CITATION.cff** (new) — mirrors `reacher-z/ClawBench/CITATION.cff`. \`preferred-citation\` is the ClawBench paper, so GitHub's "Cite this repository" widget surfaces the canonical reference.

## Test plan

- [x] Verify the BibTeX block matches reacher-z/ClawBench README byte-for-byte (modulo surrounding prose)
- [x] CITATION.cff validates locally (cff-version 1.2.0)
- [ ] After merge - confirm GitHub's "Cite this repository" widget on the repo home reads "arXiv preprint arXiv:2604.08523"